### PR TITLE
Add time-admin dependency check on systemd

### DIFF
--- a/capplets/Makefile.am
+++ b/capplets/Makefile.am
@@ -8,10 +8,13 @@ SUBDIRS = \
 	keybindings \
 	mouse \
 	network \
-	time-admin \
 	windows \
 	about-me \
 	system-info
+
+if HAVE_SYSTEMD
+SUBDIRS += time-admin
+endif
 
 DIST_SUBDIRS = \
 	common \


### PR DESCRIPTION
time-admin depends on systemd. If systemd is not used in the systemd, time-admin is disabled